### PR TITLE
Slam 56 - Simulate IMU in Gazebo

### DIFF
--- a/slam-ws/src/caffeine/launch/caffeine_setup.launch
+++ b/slam-ws/src/caffeine/launch/caffeine_setup.launch
@@ -29,7 +29,7 @@
     </node>
 
     <!-- Set up the IMU -->
-    <node pkg="tf" type="static_transform_publisher" name="base_laser_to_imu_broadcaster" args="0 0 0 0 0 0 base_laser imu 100"/>
+    <node pkg="tf" type="static_transform_publisher" name="imu_link_to_imu_broadcaster" args="0 0 0 0 0 0 imu_link imu 100"/>
     
     <include file="$(find phidgets_imu)/launch/imu_single_nodes.launch"/>
 

--- a/slam-ws/src/caffeine/urdf/caffeine.gazebo.xacro
+++ b/slam-ws/src/caffeine/urdf/caffeine.gazebo.xacro
@@ -99,6 +99,27 @@
       </sensor>
    </gazebo>
 
+   <!-- TODO: Update values based on Phidget IMU specifications -->
+   <gazebo reference="imu_link">
+      <gravity>true</gravity>
+      <sensor name="imu_sensor" type="imu">
+         <always_on>true</always_on>
+         <update_rate>100</update_rate>
+         <visualize>true</visualize>
+         <topic>__default_topic__</topic>
+         <plugin filename="libgazebo_ros_imu_sensor.so" name="imu_plugin">
+            <topicName>imu</topicName>
+            <bodyName>imu_link</bodyName>
+            <updateRateHZ>10.0</updateRateHZ>
+            <gaussianNoise>0.0</gaussianNoise>
+            <xyzOffset>0 0 0</xyzOffset>
+            <rpyOffset>0 0 0</rpyOffset>
+            <frameName>imu_link</frameName>
+         </plugin>
+         <pose>0 0 0 0 0 0</pose>
+      </sensor>
+  </gazebo>
+
    <gazebo>
       <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
          <legacyModeNS>true</legacyModeNS>

--- a/slam-ws/src/caffeine/urdf/caffeine.gazebo.xacro
+++ b/slam-ws/src/caffeine/urdf/caffeine.gazebo.xacro
@@ -99,25 +99,27 @@
       </sensor>
    </gazebo>
 
-   <!-- TODO: Update values based on Phidget IMU specifications -->
+   <!-- Phidgets IMU specifications -->
    <gazebo reference="imu_link">
       <material>Gazebo/Black</material>
 
       <gravity>true</gravity>
       <sensor name="imu_sensor" type="imu">
          <always_on>true</always_on>
-         <update_rate>100</update_rate>
+         <update_rate>128</update_rate>
          <visualize>true</visualize>
-         <topic>__default_topic__</topic>
+         <topic>imu/data_raw</topic>
+
          <plugin filename="libgazebo_ros_imu_sensor.so" name="imu_plugin">
             <topicName>imu/data_raw</topicName>
             <bodyName>imu_link</bodyName>
-            <updateRateHZ>10.0</updateRateHZ>
-            <gaussianNoise>0.0</gaussianNoise>
+            <updateRateHZ>128.0</updateRateHZ>
+            <gaussianNoise>0.59</gaussianNoise>
             <xyzOffset>0 0 0</xyzOffset>
             <rpyOffset>0 0 0</rpyOffset>
             <frameName>imu_link</frameName>
          </plugin>
+         
          <pose>0 0 0 0 0 0</pose>
       </sensor>
   </gazebo>

--- a/slam-ws/src/caffeine/urdf/caffeine.gazebo.xacro
+++ b/slam-ws/src/caffeine/urdf/caffeine.gazebo.xacro
@@ -101,6 +101,8 @@
 
    <!-- TODO: Update values based on Phidget IMU specifications -->
    <gazebo reference="imu_link">
+      <material>Gazebo/Black</material>
+
       <gravity>true</gravity>
       <sensor name="imu_sensor" type="imu">
          <always_on>true</always_on>
@@ -108,7 +110,7 @@
          <visualize>true</visualize>
          <topic>__default_topic__</topic>
          <plugin filename="libgazebo_ros_imu_sensor.so" name="imu_plugin">
-            <topicName>imu</topicName>
+            <topicName>imu/data_raw</topicName>
             <bodyName>imu_link</bodyName>
             <updateRateHZ>10.0</updateRateHZ>
             <gaussianNoise>0.0</gaussianNoise>

--- a/slam-ws/src/caffeine/urdf/caffeine.urdf.xacro
+++ b/slam-ws/src/caffeine/urdf/caffeine.urdf.xacro
@@ -276,6 +276,7 @@
       <origin rpy="0 0 0" xyz="0 0 0"/>
    </joint>
 
+   <!-- LIDAR -->
    <link name="base_laser">
       <visual>
          <origin xyz="0 0 ${-hokuyo_height/2.0}" rpy="0 0 0"/>
@@ -299,4 +300,41 @@
       <child link="base_laser"/>
       <origin xyz="${base_width/2.0} 0 ${base_height/2.0 + hokuyo_height/2.0 + hokuyo_height/2.0}" rpy="0 0 ${-135*pi/180}"/>
    </joint>
+
+   <!-- IMU -->
+   <link name="imu_link">
+      <inertial>
+         <origin xyz="0 0 0" rpy="0 0 0"/>
+         <mass value="0"/>
+         <inertia
+         ixx="1.0" ixy="0.0" ixz="0.0"
+         iyy="1.0" iyz="0.0"
+         izz="1.0"/>
+      </inertial>
+
+      <visual>
+         <origin xyz="0 0 0" rpy="0 0 0"/>
+         <geometry>
+            <box size="0.05 0.03 0.005"/>
+         </geometry>
+         <material name="green">
+            <color rgba="0 0.5 0 0.5"/>
+         </material>
+      </visual>
+
+      <collision>
+         <origin xyz="0 0 0" rpy="0 0 0"/>
+         <geometry>
+            <box size="0.05 0.03 0.005"/>
+         </geometry>
+      </collision>
+   </link>
+
+   <!-- Attach imu link to base link -->
+   <joint name="base_link_to_imu_link" type="fixed">
+      <parent link="base_link"/>
+      <child link="imu_link"/>
+      <origin xyz="0.1 -0.025 0.06" rpy="0 0 0"/>
+   </joint>
+
 </robot>

--- a/slam-ws/src/caffeine/urdf/caffeine.urdf.xacro
+++ b/slam-ws/src/caffeine/urdf/caffeine.urdf.xacro
@@ -278,63 +278,60 @@
 
    <!-- LIDAR -->
    <link name="base_laser">
-      <visual>
-         <origin xyz="0 0 ${-hokuyo_height/2.0}" rpy="0 0 0"/>
-         <geometry>
-            <mesh filename="package://caffeine/urdf/meshes/hokuyo.dae"/>
-         </geometry>
-      </visual>
-      <collision>
-         <origin xyz="0 0 ${-hokuyo_height/2.0}" rpy="0 0 0"/>
-         <geometry>
-            <box size="${hokuyo_length} ${hokuyo_width} ${hokuyo_height}"/>
-         </geometry>
-      </collision>
       <inertial>
          <mass value="${hokuyo_mass}"/>
          <xacro:box_inertia mass="${hokuyo_mass}" length="${hokuyo_length}" width="${hokuyo_width}" height="${hokuyo_height}"/>
       </inertial>
+      
+      <visual>
+         <origin xyz="0 0 0" rpy="0 0 0"/>
+         <geometry>
+            <mesh filename="package://caffeine/urdf/meshes/hokuyo.dae"/>
+         </geometry>
+      </visual>
+
+      <collision>
+         <origin xyz="0 0 0" rpy="0 0 0"/>
+         <geometry>
+            <box size="${hokuyo_length} ${hokuyo_width} ${hokuyo_height}"/>
+         </geometry>
+      </collision>
    </link>
+
+   <!-- LIDAR: attach base_laser to base_link -->
    <joint name="base_laser_joint" type="fixed">
       <parent link="base_link"/>
       <child link="base_laser"/>
-      <origin xyz="${base_width/2.0} 0 ${base_height/2.0 + hokuyo_height/2.0 + hokuyo_height/2.0}" rpy="0 0 ${-135*pi/180}"/>
+      <origin xyz="${base_width / 2.0} 0 ${base_height / 2.0 + hokuyo_height / 2.0}" rpy="0 0 ${-135 * pi / 180}"/>
    </joint>
 
    <!-- IMU -->
    <link name="imu_link">
       <inertial>
-         <origin xyz="0 0 0" rpy="0 0 0"/>
-         <mass value="0"/>
-         <inertia
-         ixx="1.0" ixy="0.0" ixz="0.0"
-         iyy="1.0" iyz="0.0"
-         izz="1.0"/>
+         <mass value="${phidget_mass}"/>
+         <xacro:box_inertia mass="${phidget_mass}" length="${phidget_length}" width="${phidget_width}" height="${phidget_height}"/>
       </inertial>
 
       <visual>
          <origin xyz="0 0 0" rpy="0 0 0"/>
          <geometry>
-            <box size="0.05 0.03 0.005"/>
+            <box size="${phidget_length} ${phidget_width} ${phidget_height}"/>
          </geometry>
-         <material name="green">
-            <color rgba="0 0.5 0 0.5"/>
-         </material>
       </visual>
 
       <collision>
          <origin xyz="0 0 0" rpy="0 0 0"/>
          <geometry>
-            <box size="0.05 0.03 0.005"/>
+            <box size="${phidget_length} ${phidget_width} ${phidget_height}"/>
          </geometry>
       </collision>
    </link>
 
-   <!-- Attach imu link to base link -->
+   <!-- IMU: attach imu_link to base_link -->
    <joint name="base_link_to_imu_link" type="fixed">
       <parent link="base_link"/>
       <child link="imu_link"/>
-      <origin xyz="0.1 -0.025 0.06" rpy="0 0 0"/>
+      <origin xyz="${base_width / 2.0 - 0.1} 0 ${base_height / 2.0 + phidget_height / 2.0}" rpy="0 0 0"/>
    </joint>
 
 </robot>

--- a/slam-ws/src/caffeine/urdf/constants.xacro
+++ b/slam-ws/src/caffeine/urdf/constants.xacro
@@ -32,6 +32,12 @@
    <xacro:property name="hokuyo_height" value="0.07"/>
    <xacro:property name="hokuyo_mass" value="0.16"/>
 
+   <!-- Constants for Phidget IMU -->
+   <xacro:property name="phidget_length" value="0.04"/>
+   <xacro:property name="phidget_width" value="0.0375"/>
+   <xacro:property name="phidget_height" value="0.01"/>
+   <xacro:property name="phidget_mass" value="0.04"/>
+
    <!-- Constants for the basement -->
    <xacro:property name="basement_height" value="0.103"/>
    <xacro:property name="basement_width" value="0.305"/>


### PR DESCRIPTION
Simulated Phidgets IMU using Gazebo IMU plugin.
- Can probably improve noise models for IMU (but will leave this for when Simulation doesn't match Reality approximately)
- Added `imu_link` to the transform tree
- IMU publishes to `imu/data_raw` but uses the correct `frame_id` - does not require a static broadcaster like in reality. We may want to decide if we want to include this for simulation to be more accurate with reality, lmk what you think!