### PR TITLE
Slam 57 - Adding GPS to Caffeine

### DIFF
--- a/slam-ws/src/caffeine/urdf/caffeine.gazebo.xacro
+++ b/slam-ws/src/caffeine/urdf/caffeine.gazebo.xacro
@@ -177,23 +177,24 @@
 
    <!-- For details about plugin, see: http://wiki.ros.org/hector_gazebo_plugins -->
    <!-- TODO: update these parameters to match real life Garmin. See: http://static.garmin.com/pumac/425_TechnicalSpecification.pdf -->
-   <!-- For testing purposes, this is not accurate -->
-   <!-- Also, it was difficult to test this. It seems to work, but more testing MUST be done -->
-  <gazebo>
+   <gazebo>
       <plugin name="gps_controller" filename="libhector_gazebo_ros_gps.so">
-        <updateRate>40.0</updateRate>
-        <bodyName>gps_link</bodyName>
-        <frameId>gps_link</frameId>
-        <topicName>gps/fix</topicName>
-        <velocityTopicName>gps/fix_velocity</velocityTopicName>
-        <referenceHeading>0</referenceHeading>
-        <referenceAltitude>0</referenceAltitude>
-        <!-- TODO: change drift parameter & gaussian noise parameters -->
-	<!-- Also might need to add velocity drift & gaussian noise for  velocity -->
-        <drift>0.0001 0.0001 0.0001</drift>
-        <gaussianNoise>0.01 0.01 0.1</gaussianNoise>
+         <updateRate>5.0</updateRate>  <!-- 5 Hz -->
+         <bodyName>gps_link</bodyName>
+         <frameId>gps_link</frameId>
+         <topicName>gps/fix</topicName>
+         <velocityTopicName>gps/fix_velocity</velocityTopicName>
+         <!-- Set reference GPS coordinates to UofT -->
+         <referenceLatitude>43.6570</referenceLatitude>
+         <referenceLongitude>-79.3903</referenceLongitude>
+         <referenceAltitude>76</referenceAltitude>
+         <!-- Model GPS behaviour -->
+         <service>1</service> <!-- SERVICE_GPS = 1 -->
+         <drift>1.5 1.5 1.5</drift> <!-- m -->
+         <velocityDrift>0.05 0.05 0.05</velocityDrift> <!-- m/s-->
+         <!-- TODO: add Gaussian noise based off Garmin GPS -->
       </plugin>
-  </gazebo>
+   </gazebo>
 
    <gazebo>
       <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">

--- a/slam-ws/src/caffeine/urdf/caffeine.gazebo.xacro
+++ b/slam-ws/src/caffeine/urdf/caffeine.gazebo.xacro
@@ -175,6 +175,26 @@
       </sensor>
   </gazebo>
 
+   <!-- For details about plugin, see: http://wiki.ros.org/hector_gazebo_plugins -->
+   <!-- TODO: update these parameters to match real life Garmin. See: http://static.garmin.com/pumac/425_TechnicalSpecification.pdf -->
+   <!-- For testing purposes, this is not accurate -->
+   <!-- Also, it was difficult to test this. It seems to work, but more testing MUST be done -->
+  <gazebo>
+      <plugin name="gps_controller" filename="libhector_gazebo_ros_gps.so">
+        <updateRate>40.0</updateRate>
+        <bodyName>gps_link</bodyName>
+        <frameId>gps_link</frameId>
+        <topicName>gps/fix</topicName>
+        <velocityTopicName>gps/fix_velocity</velocityTopicName>
+        <referenceHeading>0</referenceHeading>
+        <referenceAltitude>0</referenceAltitude>
+        <!-- TODO: change drift parameter & gaussian noise parameters -->
+	<!-- Also might need to add velocity drift & gaussian noise for  velocity -->
+        <drift>0.0001 0.0001 0.0001</drift>
+        <gaussianNoise>0.01 0.01 0.1</gaussianNoise>
+      </plugin>
+  </gazebo>
+
    <gazebo>
       <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
          <legacyModeNS>true</legacyModeNS>

--- a/slam-ws/src/caffeine/urdf/caffeine.urdf.xacro
+++ b/slam-ws/src/caffeine/urdf/caffeine.urdf.xacro
@@ -377,4 +377,32 @@
       <origin xyz="${base_width / 2.0 - 0.1} 0 ${base_height / 2.0 + phidget_height / 2.0}" rpy="0 0 0"/>
    </joint>
 
+  <!-- GPS -->
+  <link name="gps_link">
+      <inertial>
+          <mass value="${gps_mass}"/>
+          <xacro:cylinder_inertia mass="${gps_mass}" length="${gps_length}" radius="${gps_diam / 2.0}"/>
+      </inertial>
+
+      <visual>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry>
+              <cylinder length="${gps_length}" radius="${gps_diam / 2.0}"/>
+          </geometry>
+      </visual>
+      <collision>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry>
+              <cylinder length="${gps_length}" radius="${gps_diam / 2.0}"/>
+          </geometry>
+      </collision>
+  </link>
+
+  <!-- GPS: attach gps_link to base_link -->
+  <joint name="gps_joint" type="fixed">
+      <parent link="base_link"/>
+      <child link="gps_link"/>
+      <origin xyz="${-base_width / 2.0 - 0.1} 0 ${base_height / 2.0 + gps_length / 2.0}" rpy="0 0 0"/>
+  </joint>
+
 </robot>

--- a/slam-ws/src/caffeine/urdf/constants.xacro
+++ b/slam-ws/src/caffeine/urdf/constants.xacro
@@ -62,4 +62,11 @@
   <xacro:property name="ZED_camera_length" value="0.175"/>
   <xacro:property name="ZED_camera_width" value="0.03"/>
   <xacro:property name="ZED_camera_height" value="0.033"/>
+
+  <!-- Constants for Garmin GPS -->
+  <!-- NOTE: approx as a cylinder; garmin itself is similar to a hockey puck -->
+  <xacro:property name="gps_diam" value="0.061"/>
+  <xacro:property name="gps_length" value="0.0195"/>
+  <xacro:property name="gps_mass" value="0.165"/>
+
 </robot>


### PR DESCRIPTION
Added GPS sim to caffeine. It launches through the normal way.

Created a link: `gps_link` for the gps
Nodes that gps publishes it's data to are `gps/fix` and `gps/fix_velocity`
By default, it assumes the robot starts at 49.9, 8.9 and at an altitude of 0

I highly recommend testing this out on Gazebo before accepting this PR as it was difficult to determine whether the GPS works correctly. Currently, there does seem to be a consistent change when I was moving it along axes, but I recommend you test it out yourself to make sure we get the desired effects from the gps.