### PR TITLE
SLAM-96: Adding min/max speed 

### DIFF
--- a/slam-ws/src/nav_stack/config/base_local_planner_params.yaml
+++ b/slam-ws/src/nav_stack/config/base_local_planner_params.yaml
@@ -7,8 +7,8 @@ NavfnROS:
 
 # Plans robot movement [I think]
 TrajectoryPlannerROS:
-  max_vel_x: 0.45
-  min_vel_x: 0.1
+  max_vel_x: 2.0
+  min_vel_x: 0.2
   max_vel_theta: 1.0
   min_in_place_vel_theta: 0.4
 

--- a/slam-ws/src/odom/config/localization.yaml
+++ b/slam-ws/src/odom/config/localization.yaml
@@ -20,7 +20,7 @@ print_diagnostics: true
 
 odom0: odom
 odom0_config: [true,  true,  false,
-               false, false, false,
+               false, false, true,
                true,  true,  false,
                false, false, true,
                false, false, false]
@@ -32,7 +32,7 @@ odom0_relative: false
 
 imu0: imu/data
 imu0_config:  [false, false, false,
-               false, false, true,
+               false, false, false,
                true,  true,  false,
                false, false, true,
                true, true, false]


### PR DESCRIPTION
Added min/max speed and and disabling SLAM-87 changes to temporarily improve odom.

The robot now moves a lot faster. It was previously going at around .44m/s (which is approx 1mile/hour, the minimum average speed) and could not go faster since .45 was the max speed set in the params. I have increased the max to 2.0m/s, and now it seems to be moving at around 1.5m/s (I am checking by looking at the topic /gazebo/model_states/twist). We can tune the values of min and max but it seems to be moving at an acceptable speed now. Very easy to tune. I increased the minimum just to make sure that the robot moves quickly, but I am uncertain this is necessary, however doesnt seem to hurt. 

Also have been having a lot of issues with odom. I fixed some of them by disabling what was done in SLAM-87, however, the odom still sucks. I needed to redo the simulation tens of times to get accurate results. Something is definitely wrong, even before my changes. 